### PR TITLE
autogen.sh: Added support of "NOCONFIGURE" environmental variable and code fixes

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -24,5 +24,6 @@ if cd "$srcdir"; then
     autoreconf --install --symlink
     intltoolize --force
     autoreconf
-    [ -n "$NOCONFIGURE" ] && ./configure --enable-maintainer-mode "$@"
+    # Run ./configure if NOCONFIGURE environmental variable is not defined (is empty)
+    [ -z "$NOCONFIGURE" ] && ./configure --enable-maintainer-mode "$@"
 fi

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,23 +1,29 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
 
-srcdir=`dirname $0`
+srcdir="$(dirname "$0")"
 test -z "$srcdir" && srcdir=.
 REQUIRED_AUTOMAKE_VERSION=1.9
 PKG_NAME=NetworkManager-openvpn
 
-(test -f $srcdir/configure.ac \
-  && test -f $srcdir/auth-dialog/main.c) || {
-    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
+{ test -f "$srcdir/configure.ac" \
+  && test -f "$srcdir/auth-dialog/main.c"; } || {
+    echo "**Error**: Directory ${srcdir} does not look like the"
     echo " top-level $PKG_NAME directory"
     exit 1
 }
 
-(cd $srcdir;
-    autoreconf --install --symlink &&
-    intltoolize --force &&
-    autoreconf &&
-    ./configure --enable-maintainer-mode $@
-)
+for test_tool in autoreconf intltoolize
+do
+	[ -x "$(command -v "$test_tool")" ] || {
+		echo "${test_tool} was not found!"
+		exit 1
+	}
+done
 
-
+if cd "$srcdir"; then
+    autoreconf --install --symlink
+    intltoolize --force
+    autoreconf
+    [ -n "$NOCONFIGURE" ] && ./configure --enable-maintainer-mode "$@"
+fi

--- a/autogen.sh
+++ b/autogen.sh
@@ -8,8 +8,7 @@ PKG_NAME=NetworkManager-openvpn
 
 { test -f "$srcdir/configure.ac" \
   && test -f "$srcdir/auth-dialog/main.c"; } || {
-    echo "**Error**: Directory ${srcdir} does not look like the"
-    echo " top-level $PKG_NAME directory"
+    echo "**Error**: Directory ${srcdir} does not look like the top-level ${PKG_NAME} directory"
     exit 1
 }
 


### PR DESCRIPTION
Added support of "NOCONFIGURE" environmental variable.
Fixes to code according to shellcheck.

Example usage:
in RPM spec we do not want to call `./confiogure`, we want to use
a special macro, e.g. %configure or %configure2_5x,
which will automatically set different flags and options.
So, we take a pure git tarball and run:
`env NOCONFIGURE=autogen.sh`
`%configure2_5x`
https://abf.io/mikhailnov/networkmanager-openvpn/blob/rosa2016.1/networkmanager-openvpn.spec#lc-63 