### PR TITLE
Move D-Bus conf file to $(datadir)/dbus-1/system.d

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ SUBDIRS = \
 plugindir = $(libdir)/NetworkManager
 plugin_LTLIBRARIES =
 
-dbusservicedir = $(sysconfdir)/dbus-1/system.d
+dbusservicedir = $(datadir)/dbus-1/system.d
 dbusservice_DATA = nm-openvpn-service.conf
 
 nmvpnservicedir = $(NM_VPN_SERVICE_DIR)


### PR DESCRIPTION
Since D-Bus 1.9.18 configuration files installed by third-party should
go in share/dbus-1/system.d. The old location is for sysadmin overrides.