### PR TITLE
Clarify boolean error message

### DIFF
--- a/src/nm-openvpn-service.c
+++ b/src/nm-openvpn-service.c
@@ -449,7 +449,7 @@ validate_one_property (const char *key, const char *value, gpointer user_data)
 			             NM_VPN_PLUGIN_ERROR,
 			             NM_VPN_PLUGIN_ERROR_BAD_ARGUMENTS,
 			             /* Translators: keep "yes" and "no" untranslated! */
-			             _("invalid boolean property “%s” (not yes or no)"),
+			             _("invalid boolean property “%s” (needs to be yes or no, not true or false)"),
 			             key);
 			break;
 		default:


### PR DESCRIPTION
The validation accepts "yes" or "no" as valid values, but then proceeds to report "NOT yes or no" as an error message in case of a validation failure.
This clarifies the error message to better hint at what the valid, and what the invalid values are.